### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,64 +6,64 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-PID					KEYWORD1
-ESC					KEYWORD1
-MPU6050				KEYWORD1
-RX					KEYWORD1
-BAT					KEYWORD1
-LED					KEYWORD1
-TIMER				KEYWORD1
-INTERRUPT			KEYWORD1
-MATH				KEYWORD1
+PID	KEYWORD1
+ESC	KEYWORD1
+MPU6050	KEYWORD1
+RX	KEYWORD1
+BAT	KEYWORD1
+LED	KEYWORD1
+TIMER	KEYWORD1
+INTERRUPT	KEYWORD1
+MATH	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setOutputLimits		KEYWORD2
-setGainValues		KEYWORD2
-setDirection		KEYWORD2
-calculate			KEYWORD2
+setOutputLimits	KEYWORD2
+setGainValues	KEYWORD2
+setDirection	KEYWORD2
+calculate	KEYWORD2
 getMinOutputLimit	KEYWORD2
 getMaxOutputLimit	KEYWORD2
 getProportionalGain	KEYWORD2
-getIntegralGain		KEYWORD2
+getIntegralGain	KEYWORD2
 getDifferentialGain	KEYWORD2
-GetDirection		KEYWORD2
+GetDirection	KEYWORD2
 
-activate			KEYWORD2
-writeByte			KEYWORD2
-writeWord			KEYWORD2
-setScale			KEYWORD2
-getAddress			KEYWORD2
-readByte			KEYWORD2
-readWord			KEYWORD2
-readGyroscope		KEYWORD2
-readAccelero		KEYWORD2
+activate	KEYWORD2
+writeByte	KEYWORD2
+writeWord	KEYWORD2
+setScale	KEYWORD2
+getAddress	KEYWORD2
+readByte	KEYWORD2
+readWord	KEYWORD2
+readGyroscope	KEYWORD2
+readAccelero	KEYWORD2
 
-writePulse			KEYWORD2
+writePulse	KEYWORD2
 
-begin				KEYWORD2
-end					KEYWORD2
-timeOut				KEYWORD2
-setSpeed			KEYWORD2
-pullup				KEYWORD2
-scan				KEYWORD2
-write				KEYWORD2
-read				KEYWORD2
-available			KEYWORD2
-receive				KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+timeOut	KEYWORD2
+setSpeed	KEYWORD2
+pullup	KEYWORD2
+scan	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
+available	KEYWORD2
+receive	KEYWORD2
 
 #######################################
 # Objects and instances (KEYWORD3)
 #######################################
 
-vector				KEYWORD3
-quaternion			KEYWORD3
+vector	KEYWORD3
+quaternion	KEYWORD3
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-DIRECT				LITERAL1
-REVERSE				LITERAL1
+DIRECT	LITERAL1
+REVERSE	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords